### PR TITLE
Feat/add calibri as font family

### DIFF
--- a/src/assets/scss/bbmri.scss
+++ b/src/assets/scss/bbmri.scss
@@ -14,6 +14,10 @@ $default-text-color: white;
 
 @import "node_modules/bootstrap/scss/bootstrap";
 
+body {
+    font-family: Calibri, Arial, sans-serif;
+}
+  
 .btn-primary {
     color: white;
 }

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -82,11 +82,6 @@ export default {
 </script>
 <style scoped>
 h1 {
-  font-family: Calibri, Arial, sans-serif;
   font-size: 3.5rem;
-}
-
-h2 {
-  font-family: Calibri, Arial, sans-serif;
 }
 </style>

--- a/src/views/NegotiationPage.vue
+++ b/src/views/NegotiationPage.vue
@@ -531,9 +531,3 @@ export default {
   },
 }
 </script>
-
-<style scoped>
-h1 {
-  font-family: Calibri, Arial, sans-serif;
-}
-</style>


### PR DESCRIPTION
Added font-family: Calibri, Arial, sans-serif .So if the browser can't use Calibri, it will use the Arial font. The font is set to the body so it will be applied to every text if it doesn't have a font defined.